### PR TITLE
Corrected skip for escaping quotes and apostrophes

### DIFF
--- a/syntax/xquery.vim
+++ b/syntax/xquery.vim
@@ -16,8 +16,8 @@ setlocal iskeyword+=.,-
 syn match   xqyQName            /\k\+\(:\k\+\)\?/ contained contains=NONE transparent 
 syn region  xqyBlock            start=/{/ end=/}/ contains=ALLBUT,@xqyPrologStatements
 
-syn region  xqyString           start=/\z(['"]\)/ skip=/\\\z1/ end=/\z1/ keepend
-syn region  xqyAttrString       start=/\z(['"]\)/ skip=/\\\z1/ end=/\z1/ contained contains=xqyBlock
+syn region  xqyString           start=/\z(['"]\)/ skip=/\z1\z1/ end=/\z1/ keepend
+syn region  xqyAttrString       start=/\z(['"]\)/ skip=/\z1\z1/ end=/\z1/ contained contains=xqyBlock
 syn region  xqyStartTag         start=#<\([= \/]\)\@!# end=#># contains=xqyAttrString
 syn region  xqyEndTag           start=#</# end=#># contains=xqyQName
 


### PR DESCRIPTION
Per the xquery spec, quotes (https://www.w3.org/TR/xquery-31/#prod-xquery31-EscapeQuot) are escaped with another quote and apostrophes (https://www.w3.org/TR/xquery-31/#doc-xquery31-EscapeApos) are escaped with another apostrophe.  In fact, for pure syntax highlighting, no skip is even needed.  Syntax highlighting on two adjacent strings, looks identical to the syntax highlighting on a string with an embedded quote, or apostrophe.  However, it's possible that this could impact some other functionality of which I'm unaware, so it's probably safest to just use the correct skip.